### PR TITLE
Decrypt Wasm Messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,8 @@ file(GLOB_RECURSE LIB_SRC
         ${CMAKE_CURRENT_SOURCE_DIR}/app/src/tx_parser.c
         ${CMAKE_CURRENT_SOURCE_DIR}/app/src/tx_display.c
         ${CMAKE_CURRENT_SOURCE_DIR}/app/src/tx_validate.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/app/src/base64/base64_encoder.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/app/src/secret_wasm.c
         )
 
 add_library(app_lib STATIC

--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@
 Original Ledger app for Cosmos developed by zondax.ch
 _Please visit their website at [zondax.ch](https://zondax.ch)_
 
-Forked and modified for the Secret Network by Secret Saturn.
+Forked and modified for the Secret Network by Secret Saturn and StarShell.
 
-If you want to support us, please consider delegating to our validator here, thank you: 
-[🪐 Secret Saturn Validator](https://secretnodes.com/secret/chains/secret-4/validators/E855109B212B9EB65C982FD44EE13E77E9E33C4A)
+If you want to support us, please consider delegating to our validators here, thank you: 
+[🪐 Secret Saturn Validator](https://secretnodes.com/secret/validators/secretvaloper1q0rth4fu4svxnw63vjd7w74nadzsdp0fmkhj3d)
+[StarShell Validator](https://secretnodes.com/secret/validators/secretvaloper1yv9f4tankaktdtf8lq6rjsx9c9rpfptc7kzhz2)
 
 ---
 

--- a/app/Makefile.version
+++ b/app/Makefile.version
@@ -1,6 +1,6 @@
 # This is the `transaction_version` field of `Runtime`
 APPVERSION_M=2
 # This is the `spec_version` field of `Runtime`
-APPVERSION_N=34
+APPVERSION_N=36
 # This is the patch version of this release
-APPVERSION_P=1
+APPVERSION_P=0

--- a/app/src/apdu_handler.c
+++ b/app/src/apdu_handler.c
@@ -56,7 +56,7 @@ __Z_INLINE void handleGetAddrSecp256K1(volatile uint32_t *flags, volatile uint32
     THROW(APDU_CODE_OK);
 }
 
-__Z_INLINE void handleSignSecp256K1(volatile uint32_t *flags, volatile uint32_t *tx, uint32_t rx) {
+__Z_INLINE void handleSignSecp256K1(volatile uint32_t *flags, volatile uint32_t *tx, uint32_t rx, uint8_t ins) {
     if (!process_chunk(tx, rx)) {
         THROW(APDU_CODE_OK);
     }
@@ -69,7 +69,7 @@ __Z_INLINE void handleSignSecp256K1(volatile uint32_t *flags, volatile uint32_t 
     }
     parser_tx_obj.own_addr = (const char *) (G_io_apdu_buffer + VIEW_ADDRESS_OFFSET_SECP256K1);
 
-    const char *error_msg = tx_parse();
+    const char *error_msg = tx_parse(ins == INS_SIGN_SECP256K1_DECRYPT? TX_MODE_DECRYPT: TX_MODE_RAW);
 
     if (error_msg != NULL) {
         int error_msg_length = strlen(error_msg);
@@ -113,11 +113,12 @@ void handleApdu(volatile uint32_t *flags, volatile uint32_t *tx, uint32_t rx) {
                     break;
                 }
 
-                case INS_SIGN_SECP256K1: {
+                case INS_SIGN_SECP256K1:
+                case INS_SIGN_SECP256K1_DECRYPT: {
                     if( os_global_pin_is_validated() != BOLOS_UX_OK ) {
                         THROW(APDU_CODE_COMMAND_NOT_ALLOWED);
                     }
-                    handleSignSecp256K1(flags, tx, rx);
+                    handleSignSecp256K1(flags, tx, rx, G_io_apdu_buffer[OFFSET_INS]);
                     break;
                 }
 

--- a/app/src/base64/base64_decoder.c
+++ b/app/src/base64/base64_decoder.c
@@ -1,0 +1,72 @@
+/*******************************************************************************
+*   (c) 2023 Solar Republic LLC
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+********************************************************************************/
+
+#include "base64_decoder.h"
+
+int base64_reverse_lookup(char c) {
+    if (c >= 'A' && c <= 'Z') {
+        return c - 'A';
+    } else if (c >= 'a' && c <= 'z') {
+        return c - 'a' + 26;
+    } else if (c >= '0' && c <= '9') {
+        return c - '0' + 52;
+    } else if (c == '+') {
+        return 62;
+    } else if (c == '/') {
+        return 63;
+    }
+
+    return -1;
+}
+
+int base64_decode(const uint8_t *in, uint16_t in_len, char* out, uint16_t *out_len) {
+    uint16_t max_len = BASE64_DECODED_LEN(in_len);
+
+    // output buffer does not have enough space
+    if(max_len > *out_len) return -2;
+
+    // set output length return
+    *out_len = max_len;
+
+    // trim padding
+    if (in[in_len - 1] == '=') {
+        (*out_len)--;
+
+        if (in[in_len - 2] == '=') {
+            (*out_len)--;
+        }
+    }
+
+    // decode
+    for (uint16_t read = 0, write = 0; read < in_len; ++read) {
+        int a = in[read] == '=' ? 0 : base64_reverse_lookup(in[read]);
+        int b = in[++read] == '=' ? 0 : base64_reverse_lookup(in[read]);
+        int c = in[++read] == '=' ? 0 : base64_reverse_lookup(in[read]);
+        int d = in[++read] == '=' ? 0 : base64_reverse_lookup(in[read]);
+
+        if(a == -1 || b == -1 || c == -1 || d == -1) return -1;
+
+        out[write++] = (a << 2) | (b >> 4);
+        if (write < *out_len) {
+            out[write++] = (b << 4) | (c >> 2);
+        }
+        if (write < *out_len) {
+            out[write++] = (c << 6) | d;
+        }
+    }
+
+    return 0;
+}

--- a/app/src/base64/base64_decoder.h
+++ b/app/src/base64/base64_decoder.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
-*  (c) 2019 Zondax GmbH
+*   (c) 2023 Solar Republic LLC
 *
 *  Licensed under the Apache License, Version 2.0 (the "License");
 *  you may not use this file except in compliance with the License.
@@ -13,37 +13,9 @@
 *  See the License for the specific language governing permissions and
 *  limitations under the License.
 ********************************************************************************/
-#pragma once
 
-#include "parser_common.h"
-#include <zxmacros.h>
-#include "zxtypes.h"
-#include "json/json_parser.h"
-#include "parser_txdef.h"
-#include "txmode_def.h"
+#include <stdint.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#define BASE64_DECODED_LEN(x) ((x * 3) / 4)
 
-typedef struct {
-    char str1[50];
-    char str2[50];
-} key_subst_t;
-
-typedef struct {
-    char str1[50];
-    char str2[50];
-} value_subst_t;
-
-extern parser_tx_t parser_tx_obj;
-
-parser_error_t parser_init(parser_context_t *ctx,
-                           const uint8_t *buffer,
-                           size_t bufferSize);
-
-parser_error_t _readTx(parser_context_t *c, tx_mode_t mode, parser_tx_t *v);
-
-#ifdef __cplusplus
-}
-#endif
+int base64_decode(const uint8_t *in, uint16_t in_len, char* out, uint16_t *out_len);

--- a/app/src/common/app_main.h
+++ b/app/src/common/app_main.h
@@ -34,6 +34,8 @@
 #define INS_SIGN_SECP256K1              0x02
 #define INS_GET_ADDR_SECP256K1          0x04
 
+#define INS_SIGN_SECP256K1_DECRYPT      0x42
+
 void app_init();
 
 void app_main();

--- a/app/src/common/parser.h
+++ b/app/src/common/parser.h
@@ -21,13 +21,15 @@ extern "C" {
 #endif
 
 #include "parser_impl.h"
+#include "txmode_def.h"
 
 const char *parser_getErrorDescription(parser_error_t err);
 
 //// parses a tx buffer
 parser_error_t parser_parse(parser_context_t *ctx,
                             const uint8_t *data,
-                            size_t dataLen);
+                            size_t dataLen,
+                            tx_mode_t mode);
 
 //// verifies tx fields
 parser_error_t parser_validate(const parser_context_t *ctx);

--- a/app/src/common/parser_common.h
+++ b/app/src/common/parser_common.h
@@ -63,6 +63,12 @@ typedef enum {
     parser_json_missing_account_number,
     parser_json_missing_memo,
     parser_json_unexpected_error,
+    // Secret specific
+    parser_invalid_tek_k,
+    parser_invalid_tek_data,
+    parser_invalid_msg_contents,
+    parser_aes_init_error,
+    parser_aes_decrypt_error,
 } parser_error_t;
 
 typedef struct {

--- a/app/src/common/tx.c
+++ b/app/src/common/tx.c
@@ -76,13 +76,14 @@ uint8_t *tx_get_buffer()
 
 static parser_tx_t tx_obj;
 
-const char *tx_parse()
+const char *tx_parse(tx_mode_t mode)
 {
     MEMZERO(&tx_obj, sizeof(tx_obj));
 
     uint8_t err = parser_parse(&ctx_parsed_tx,
                                tx_get_buffer(),
-                               tx_get_buffer_length());
+                               tx_get_buffer_length(),
+                               mode);
     zemu_log_stack("parse|parsed");
 
     if (err != parser_ok)

--- a/app/src/common/tx.h
+++ b/app/src/common/tx.h
@@ -18,6 +18,7 @@
 #include "os.h"
 #include "coin.h"
 #include "zxerror.h"
+#include "txmode_def.h"
 
 void tx_initialize();
 
@@ -42,7 +43,7 @@ uint8_t *tx_get_buffer();
 /// Parse message stored in transaction buffer
 /// This function should be called as soon as full buffer data is loaded.
 /// \return It returns NULL if data is valid or error message otherwise.
-const char *tx_parse();
+const char *tx_parse(tx_mode_t mode);
 
 /// Return the number of items in the transaction
 zxerr_t tx_getNumItems(uint8_t *num_items);

--- a/app/src/parser.c
+++ b/app/src/parser.c
@@ -27,8 +27,9 @@
 
 parser_error_t parser_parse(parser_context_t *ctx,
                             const uint8_t *data,
-                            size_t dataLen) {
-    CHECK_PARSER_ERR(tx_display_readTx(ctx, data, dataLen))
+                            size_t dataLen,
+                            tx_mode_t mode) {
+    CHECK_PARSER_ERR(tx_display_readTx(ctx, data, dataLen, mode))
     return parser_ok;
 }
 
@@ -299,7 +300,7 @@ parser_error_t parser_getItem(const parser_context_t *ctx,
     } else {
         CHECK_PARSER_ERR(tx_getToken(ret_value_token_index,
                                      outVal, outValLen,
-                                     pageIdx, pageCount))
+                                     pageIdx, pageCount, tmpKey))
     }
     CHECK_APP_CANARY()
 

--- a/app/src/parser_txdef.h
+++ b/app/src/parser_txdef.h
@@ -74,6 +74,10 @@ typedef struct {
 
     // current tx query
     tx_query_t query;
+
+    // tx encryption key
+    uint8_t tek_k;
+    const char *tek_data;
 } parser_tx_t;
 
 #ifdef __cplusplus

--- a/app/src/secret_wasm.c
+++ b/app/src/secret_wasm.c
@@ -327,7 +327,7 @@ parser_error_t decrypt_secret_wasm_msg(uint8_t *in, uint16_t in_len, uint8_t *ou
 
     // replace codepoints outside the ASCII range with a single character
     uint8_t *write = plaintext;
-    uint8_t *read = plaintext + 64;  // skip code hash
+    uint8_t *read = plaintext + CODE_HASH_LEN;  // skip code hash
     while (read < plaintext + plaintext_len && *read != '\0') {
         utf8_int32_t codepoint;
         read = (uint8_t *)utf8codepoint((const char *)read, &codepoint);

--- a/app/src/secret_wasm.c
+++ b/app/src/secret_wasm.c
@@ -40,7 +40,7 @@ void double_block(uint8_t *block) {
 }
 
 void padding(const uint8_t *data, size_t data_len, uint8_t out[AES_BLOCK_SIZE]) {
-    memcpy(out, data, data_len);
+    memmove(out, data, data_len);
 
     if (data_len < AES_BLOCK_SIZE) {
         // set high bit
@@ -51,9 +51,58 @@ void padding(const uint8_t *data, size_t data_len, uint8_t out[AES_BLOCK_SIZE]) 
     }
 }
 
-parser_error_t aes_cmac(const uint8_t *key, size_t keylen, const uint8_t *data, size_t data_len, uint8_t buffer[AES_BLOCK_SIZE]) {
+
+parser_error_t aes_cmac(cmac_context_t cmac, const uint8_t *data, size_t data_len, uint8_t buffer[AES_BLOCK_SIZE], uint8_t *s_end) {
+    // allocate new buffer so as not to mutate data
+    uint8_t m_last[AES_BLOCK_SIZE];
+
+    // cache num blocks
+    size_t num_blocks = (data_len + AES_BLOCK_SIZE - 1) / AES_BLOCK_SIZE;
+
+    // last block (either given as arg or taken from data)
+    const uint8_t *block_data = s_end != NULL? s_end: data + (((num_blocks? num_blocks: 1) - 1) * AES_BLOCK_SIZE);
+
+    // last block requires padding
+    size_t last_block_size = data_len % AES_BLOCK_SIZE;
+    if (last_block_size != 0 || num_blocks == 0) {
+        // padding(M_n)
+        padding(block_data, last_block_size, buffer);
+
+        // xor with k2
+        xor_buffers(buffer, cmac.k2, m_last, AES_BLOCK_SIZE);
+    }
+    // no padding needed; xor with k1
+    else {
+        // M_last := M_n XOR K1
+        xor_buffers(block_data, cmac.k1, m_last, AES_BLOCK_SIZE);
+    }
+
+    // X := const_Zero
+    memset(buffer, 0, AES_BLOCK_SIZE);
+
+    // for i := 1 to n-1
+    if(num_blocks) {
+        for (size_t block_idx = 0; block_idx<num_blocks-1; block_idx++) {
+            // Y := X XOR M_i
+            xor_buffers(buffer, data + (block_idx * AES_BLOCK_SIZE), buffer, AES_BLOCK_SIZE);
+
+            // X := AES-128(K,Y)
+            cx_aes(cmac.mac_key, CX_ENCRYPT, buffer, AES_BLOCK_SIZE, buffer, AES_BLOCK_SIZE);
+        }
+    }
+
+    // Y := M_last XOR X (args commuted)
+    xor_buffers(buffer, m_last, buffer, AES_BLOCK_SIZE);
+
+    // T := AES-128(K,Y)
+    cx_aes(cmac.mac_key, CX_ENCRYPT, buffer, AES_BLOCK_SIZE, buffer, AES_BLOCK_SIZE);
+
+    return parser_ok;
+}
+
+__Z_INLINE int aes_s2v(const uint8_t *mac_rkd, const uint8_t *plaintext, size_t ciphertext_len, uint8_t *cmac) {
     cx_aes_key_t mac_key;
-    cx_err_t aes_err = cx_aes_init_key_no_throw(key, keylen, &mac_key);
+    cx_err_t aes_err = cx_aes_init_key_no_throw(mac_rkd, AES_SIV_SUBKEY_LEN, &mac_key);
     if (aes_err != CX_OK) {
         return parser_aes_init_error;
     }
@@ -61,96 +110,81 @@ parser_error_t aes_cmac(const uint8_t *key, size_t keylen, const uint8_t *data, 
     // k1 subkey generation
     uint8_t k1[AES_BLOCK_SIZE];
 
-    uint8_t zero_block[AES_BLOCK_SIZE] = {0};
+    // L := AES-128(K, const_Zero)
     cx_aes(&mac_key, CX_ENCRYPT, zero_block, AES_BLOCK_SIZE, k1, AES_BLOCK_SIZE);
+
+    // K1 := L << 1  or  K1 := (L << 1) XOR const_Rb
     double_block(k1);
 
     // k2 subkey generation
     uint8_t k2[AES_BLOCK_SIZE];
     memcpy(k2, k1, AES_BLOCK_SIZE);
+
+    // K2 := K1 << 1  or  K2 := (K2 << 1) XOR const_Rb
     double_block(k2);
-    
-    // allocate new buffer so as not to mutate data
-    uint8_t m_last[AES_BLOCK_SIZE];
 
-    // cache num blocks
-    size_t num_blocks = (data_len + AES_BLOCK_SIZE - 1) / AES_BLOCK_SIZE;
+    // prep cmac context
+    cmac_context_t cmac_ctx = {&mac_key, k1, k2};
 
-    // last block
-    const uint8_t *block_data = data + ((num_blocks - 1) * AES_BLOCK_SIZE);
-
-    // last block requires padding
-    size_t last_block_size = data_len % AES_BLOCK_SIZE;
-    if (last_block_size != 0) {
-        // padding(M_n)
-        padding(block_data, last_block_size, buffer);
-
-        // xor with k2
-        xor_buffers(buffer, k2, m_last, AES_BLOCK_SIZE);
-    }
-    // no padding needed; xor with k1
-    else {
-        // M_last := M_n XOR K1
-        xor_buffers(block_data, k1, m_last, AES_BLOCK_SIZE);
-    }
-
-    // X := const_Zero
-    memset(buffer, 0, AES_BLOCK_SIZE);
-
-    // for i := 1 to n-1
-    for (size_t block_idx = 0; block_idx<num_blocks-1; block_idx++) {
-        // Y := X XOR M_i
-        xor_buffers(buffer, data + (block_idx * AES_BLOCK_SIZE), buffer, AES_BLOCK_SIZE);
-
-        // X := AES-128(K,Y)
-        cx_aes(&mac_key, CX_ENCRYPT, buffer, AES_BLOCK_SIZE, buffer, AES_BLOCK_SIZE);
-    }
-
-    // Y := M_last XOR X (args commuted)
-    xor_buffers(buffer, m_last, buffer, AES_BLOCK_SIZE);
-
-    // T := AES-128(K,Y)
-    cx_aes(&mac_key, CX_ENCRYPT, buffer, AES_BLOCK_SIZE, buffer, AES_BLOCK_SIZE);
-
-    return parser_ok;
-}
-
-__Z_INLINE int aes_s2v(const uint8_t *mac_rkd, size_t subkey_len, const uint8_t *plaintext, size_t ciphertext_len, uint8_t *cmac) {
     // D = AES-CMAC(K, <zero>)
-    uint8_t zero_block[AES_BLOCK_SIZE] = {0};
-    aes_cmac(mac_rkd, subkey_len, zero_block, AES_BLOCK_SIZE, cmac);
+    aes_cmac(cmac_ctx, zero_block, AES_BLOCK_SIZE, cmac, NULL);
 
-    PRINTF("performed first cmac: %.*h\n", AES_BLOCK_SIZE, cmac);
+    // secret network associated data
+    {
+        // ANS_1 = dbl(D)
+        double_block(cmac);
 
-    // no associated data
+        // secret network associated data
+        uint8_t ad[0];
+
+        // ANS_2 = AES-CMAC(K, Si)
+        uint8_t block[AES_BLOCK_SIZE];
+        aes_cmac(cmac_ctx, ad, 0, block, NULL);
+
+        // D = {ANS_1} xor {ANS_2}
+        xor_buffers(cmac, block, cmac, AES_BLOCK_SIZE);
+    }
+
+    // rather than modifying plaintext directly, store last block data separately
+    uint8_t s_end[AES_BLOCK_SIZE];
 
     // if len(Sn) >= 128
     if (ciphertext_len >= AES_BLOCK_SIZE) {
-        // T + Sn xorend D
-        xor_buffers(plaintext + ciphertext_len - AES_BLOCK_SIZE, cmac, cmac, AES_BLOCK_SIZE);
-        PRINTF("xorend' %.*h\n", AES_BLOCK_SIZE, cmac);
+        // T = Sn xorend D
+        xor_buffers(plaintext + ciphertext_len - AES_BLOCK_SIZE, cmac, s_end, AES_BLOCK_SIZE);
     }
     // T = dbl(D) xor pad(Sn)
     else {
+        // dbl(D)
         double_block(cmac);
         uint8_t padded[AES_BLOCK_SIZE];
         padding(plaintext, ciphertext_len, padded);
         xor_buffers(padded, cmac, cmac, AES_BLOCK_SIZE);
-        PRINTF("xor'd padded %.*h\n", AES_BLOCK_SIZE, cmac);
+
+        // keep last block as-is
+        memcpy(s_end, plaintext + ciphertext_len - AES_BLOCK_SIZE, AES_BLOCK_SIZE);
     }
 
     // V = AES-CMAC(K, T)
-    aes_cmac(mac_rkd, subkey_len, cmac, AES_BLOCK_SIZE, cmac);
+    aes_cmac(cmac_ctx, plaintext, ciphertext_len, cmac, s_end);
 
     return parser_ok;
 }
 
-parser_error_t aes_siv_decrypt(
+__Z_INLINE void increment_uint128_be(uint8_t *block) {
+    for (int i = AES_BLOCK_SIZE-1; i >= 0; --i) {
+        block[i]++;
+        if (block[i] != 0) break;
+    }
+}
+
+parser_error_t aes_siv_open(
     const uint8_t *keys,
     size_t keys_len,
     const uint8_t *payload,
     size_t payload_len,
     uint8_t *out,
+    // unint16_t out_offset,
     uint16_t *out_len
 ) {
     // AES-128 only
@@ -162,21 +196,29 @@ parser_error_t aes_siv_decrypt(
     uint8_t *plaintext = (uint8_t *)out;
 
     // extract the keys
-    size_t subkey_len = keys_len / 2;
     const uint8_t *mac_rkd = keys;
-    const uint8_t *ctr_rkd = keys + subkey_len;
+    const uint8_t *ctr_rkd = keys + AES_SIV_SUBKEY_LEN;
 
     // init ctr key
     cx_aes_key_t ctr_key;
-    cx_err_t aes_err = cx_aes_init_key_no_throw(ctr_rkd, subkey_len, &ctr_key);
-    if(aes_err != CX_OK) return parser_aes_init_error;
+    cx_err_t aes_err = cx_aes_init_key_no_throw(ctr_rkd, AES_SIV_SUBKEY_LEN, &ctr_key);
+    if (aes_err != CX_OK) return parser_aes_init_error;
+
+    // no data
+    if (payload_len < AES_BLOCK_SIZE) return parser_invalid_msg_contents;
 
     // extract tag from payload
     const uint8_t *tag = (const uint8_t *)payload;
 
     // extract ciphertext from payload
     size_t ciphertext_len = payload_len - AES_BLOCK_SIZE;
-    const uint8_t *ciphertext = payload + AES_BLOCK_SIZE;
+    const uint8_t *text = payload + AES_BLOCK_SIZE;
+
+    // nothing to decrypt
+    if (!ciphertext_len) {
+        *out_len = 0;
+        return parser_ok;
+    }
 
     // init iv using tag
     uint8_t ctr_iv[AES_BLOCK_SIZE];
@@ -186,72 +228,56 @@ parser_error_t aes_siv_decrypt(
     ctr_iv[AES_BLOCK_SIZE - 8] &= 0x7f;
     ctr_iv[AES_BLOCK_SIZE - 4] &= 0x7f;
 
+    // compute num blocks
+    size_t num_blocks = (ciphertext_len + AES_BLOCK_SIZE - 1) / AES_BLOCK_SIZE;
+
     // prep block buffer
     uint8_t block_data[AES_BLOCK_SIZE];
 
-    // the shared secret prefix will get skipped during decoding
-    size_t plaintext_len = ciphertext_len - SHARED_SECRET_LEN;
-
-    // make sure not to exceed the bounds of the output buffer
-    plaintext_len = MIN(plaintext_len, out_len);
-
-    // use read/write pointers for ciphertext/plaintext, respectively
-    uint8_t *read = ciphertext;
-    uint8_t *write = plaintext - SHARED_SECRET_LEN;
+    // decrypt in place
+    uint8_t *readwrite = text;
 
     // decrypt blocks using AES-CTR
-    for (size_t block_idx = 0; block_idx < ciphertext_len; block_idx += AES_BLOCK_SIZE) {
-        // compute intrinsic size of block
-        size_t block_len = ciphertext_len - block_idx;
-        block_len = MIN(block_len, AES_BLOCK_SIZE);
-
+    for (uint16_t block_idx = 0; block_idx < num_blocks; block_idx++) {
         // encrypt next ctr (Ledger's cx_aes_no_throw crashes the app)
         cx_aes(&ctr_key, CX_ENCRYPT, ctr_iv, AES_BLOCK_SIZE, block_data, AES_BLOCK_SIZE);
 
         // update counter
-        for (int byte_idx = AES_BLOCK_SIZE-1; byte_idx >= 0; --byte_idx) {
-            ctr_iv[byte_idx]++;
-            if (ctr_iv[byte_idx] != 0) break;
+        increment_uint128_be(ctr_iv);
+
+        // compute intrinsic size of block
+        bool_t last_block = block_idx == num_blocks - 1;
+        size_t block_len = AES_BLOCK_SIZE;
+        if (last_block) {
+            block_len = ciphertext_len % AES_BLOCK_SIZE;
+            if (0 == block_len) block_len = AES_BLOCK_SIZE;
         }
 
-        // only write once within bounds
-        if (write >= plaintext) {
-            // make sure not to exceed the bounds of the output buffer
-            size_t write_offset = block_idx - SHARED_SECRET_LEN;
-            block_len = MIN(block_len, plaintext_len - write_offset);
+        // decrypt the block
+        xor_buffers(readwrite, block_data, readwrite, block_len);
 
-            xor_buffers(read, block_data, write, block_len);
-        }
+        // advance pointer
+        readwrite += block_len;
+    }
 
-        // advance read/write pointers
-        read += block_len;
-        write += block_len;
+    // perform s2v to compute auth tag
+    uint8_t cmac[AES_BLOCK_SIZE];
+    aes_s2v(mac_rkd, text, ciphertext_len, cmac);
+
+    // check that the computed mac matches the provided tag
+    if (memcmp(cmac, tag, AES_BLOCK_SIZE) != 0) {
+        memset(plaintext, 0, ciphertext_len);
+        return parser_invalid_tek_data;
     }
 
     // set output length
-    *out_len = write >= plaintext? write - plaintext: 0;
+    *out_len = MIN(ciphertext_len, readwrite - plaintext);
 
-    // TODO: finish s2v impl
-
-    // PRINTF("init mac rkd: %.*h\n", subkey_len, mac_rkd);
-
-    // uint8_t cmac[AES_BLOCK_SIZE];
-    // aes_s2v(mac_rkd, plaintext, ciphertext_len, cmac);
-
-    // PRINTF("performed 2nd cmac %.*h <> %.*h\n", AES_BLOCK_SIZE, cmac, AES_BLOCK_SIZE, tag);
-
-    // // check that the computed mac matches the provided tag
-    // if (memcmp(cmac, tag, AES_BLOCK_SIZE) != 0) {
-
-    //     // mac mismatch, data is corrupted
-    //     // memset(plaintext, 0, ciphertext_len);
-    //     return -1;
-    // }
+    // make sure not to exceed the bounds of the output buffer
+    memmove(out, text, *out_len);
 
     return parser_ok;
 }
-
-
 
 parser_error_t decrypt_secret_wasm_msg(uint8_t *in, uint16_t in_len, uint8_t *out, uint16_t *out_len) {
     // determine max size needed for base64 decoded data and prepare a VLA
@@ -276,16 +302,19 @@ parser_error_t decrypt_secret_wasm_msg(uint8_t *in, uint16_t in_len, uint8_t *ou
     // invalid base64
     if (decode_error != 0) return parser_invalid_msg_contents;
 
+    // missing data
+    if (decoded_len < MSG_PREAMBLE_LEN) return parser_invalid_msg_contents;
+
     // skip preamble to get to payload
     uint16_t payload_len = decoded_len - MSG_PREAMBLE_LEN;
     uint8_t *payload = (uint8_t *)decoded + MSG_PREAMBLE_LEN;
 
-    // write plaintext directly to output
-    uint8_t *plaintext = (uint8_t *)out;
+    // reuse the same buffer to conserve memory; overlap w/ ciphertext is tolerated
+    uint8_t *plaintext = decoded;
     uint16_t plaintext_len;
 
     // attempt to decrypt the payload
-    parser_error_t decrypt_error = aes_siv_decrypt(
+    parser_error_t decrypt_error = aes_siv_open(
         parser_tx_obj.tek_data,
         parser_tx_obj.tek_k,
         payload,
@@ -296,24 +325,20 @@ parser_error_t decrypt_secret_wasm_msg(uint8_t *in, uint16_t in_len, uint8_t *ou
 
     if (decrypt_error != CX_OK) return decrypt_error;
 
-    // trim end of string
-    uint8_t *write = plaintext + plaintext_len;
-    while (write-- > plaintext && (*write == '\0' || *write == ' ')) {
-        *write = '\0';
-    }
-
-    // update length
-    plaintext_len = write + 1 - plaintext;
-
     // replace codepoints outside the ASCII range with a single character
-    write = plaintext;
-    uint8_t *read = plaintext;
+    uint8_t *write = plaintext;
+    uint8_t *read = plaintext + 64;  // skip code hash
     while (read < plaintext + plaintext_len && *read != '\0') {
         utf8_int32_t codepoint;
         read = (uint8_t *)utf8codepoint((const char *)read, &codepoint);
 
         // write to buffer, replacing extended character with ASCII
         *write++ = codepoint > 0x7f? '+': (char)codepoint;
+    }
+
+    // trim end of string
+    while (write > plaintext && (*write == ' ' || *write == '\0')) {
+        *write-- = '\0';
     }
 
     // write final length

--- a/app/src/secret_wasm.c
+++ b/app/src/secret_wasm.c
@@ -1,0 +1,323 @@
+/*******************************************************************************
+*   (c) 2023 Solar Republic LLC
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+********************************************************************************/
+
+#include <string.h>
+#include "utf8.h"
+#include "os_math.h"
+#include "lcx_aes.h"
+#include "zxmacros.h"
+#include "base64/base64_decoder.h"
+#include "secret_wasm.h"
+
+void xor_buffers(const uint8_t *a, const uint8_t *b, uint8_t *out, size_t out_len) {
+    for (size_t i = 0; i < out_len; ++i) {
+        out[i] = a[i] ^ b[i];
+    }
+}
+
+void double_block(uint8_t *block) {
+    uint8_t carry = block[0] & 0x80;
+
+    for (size_t i=0; i<AES_BLOCK_SIZE-1; ++i) {
+        block[i] = (block[i] << 1) | (block[i + 1] >> 7);
+    }
+    block[AES_BLOCK_SIZE-1] <<= 1;
+
+    if (carry) block[AES_BLOCK_SIZE-1] ^= 0x87;
+}
+
+void padding(const uint8_t *data, size_t data_len, uint8_t out[AES_BLOCK_SIZE]) {
+    memcpy(out, data, data_len);
+
+    if (data_len < AES_BLOCK_SIZE) {
+        // set high bit
+        out[data_len] = 0x80;
+
+        // pad remainder
+        memset(out + data_len + 1, 0, AES_BLOCK_SIZE - data_len - 1);
+    }
+}
+
+parser_error_t aes_cmac(const uint8_t *key, size_t keylen, const uint8_t *data, size_t data_len, uint8_t buffer[AES_BLOCK_SIZE]) {
+    cx_aes_key_t mac_key;
+    cx_err_t aes_err = cx_aes_init_key_no_throw(key, keylen, &mac_key);
+    if (aes_err != CX_OK) {
+        return parser_aes_init_error;
+    }
+
+    // k1 subkey generation
+    uint8_t k1[AES_BLOCK_SIZE];
+
+    uint8_t zero_block[AES_BLOCK_SIZE] = {0};
+    cx_aes(&mac_key, CX_ENCRYPT, zero_block, AES_BLOCK_SIZE, k1, AES_BLOCK_SIZE);
+    double_block(k1);
+
+    // k2 subkey generation
+    uint8_t k2[AES_BLOCK_SIZE];
+    memcpy(k2, k1, AES_BLOCK_SIZE);
+    double_block(k2);
+    
+    // allocate new buffer so as not to mutate data
+    uint8_t m_last[AES_BLOCK_SIZE];
+
+    // cache num blocks
+    size_t num_blocks = (data_len + AES_BLOCK_SIZE - 1) / AES_BLOCK_SIZE;
+
+    // last block
+    const uint8_t *block_data = data + ((num_blocks - 1) * AES_BLOCK_SIZE);
+
+    // last block requires padding
+    size_t last_block_size = data_len % AES_BLOCK_SIZE;
+    if (last_block_size != 0) {
+        // padding(M_n)
+        padding(block_data, last_block_size, buffer);
+
+        // xor with k2
+        xor_buffers(buffer, k2, m_last, AES_BLOCK_SIZE);
+    }
+    // no padding needed; xor with k1
+    else {
+        // M_last := M_n XOR K1
+        xor_buffers(block_data, k1, m_last, AES_BLOCK_SIZE);
+    }
+
+    // X := const_Zero
+    memset(buffer, 0, AES_BLOCK_SIZE);
+
+    // for i := 1 to n-1
+    for (size_t block_idx = 0; block_idx<num_blocks-1; block_idx++) {
+        // Y := X XOR M_i
+        xor_buffers(buffer, data + (block_idx * AES_BLOCK_SIZE), buffer, AES_BLOCK_SIZE);
+
+        // X := AES-128(K,Y)
+        cx_aes(&mac_key, CX_ENCRYPT, buffer, AES_BLOCK_SIZE, buffer, AES_BLOCK_SIZE);
+    }
+
+    // Y := M_last XOR X (args commuted)
+    xor_buffers(buffer, m_last, buffer, AES_BLOCK_SIZE);
+
+    // T := AES-128(K,Y)
+    cx_aes(&mac_key, CX_ENCRYPT, buffer, AES_BLOCK_SIZE, buffer, AES_BLOCK_SIZE);
+
+    return parser_ok;
+}
+
+__Z_INLINE int aes_s2v(const uint8_t *mac_rkd, size_t subkey_len, const uint8_t *plaintext, size_t ciphertext_len, uint8_t *cmac) {
+    // D = AES-CMAC(K, <zero>)
+    uint8_t zero_block[AES_BLOCK_SIZE] = {0};
+    aes_cmac(mac_rkd, subkey_len, zero_block, AES_BLOCK_SIZE, cmac);
+
+    PRINTF("performed first cmac: %.*h\n", AES_BLOCK_SIZE, cmac);
+
+    // no associated data
+
+    // if len(Sn) >= 128
+    if (ciphertext_len >= AES_BLOCK_SIZE) {
+        // T + Sn xorend D
+        xor_buffers(plaintext + ciphertext_len - AES_BLOCK_SIZE, cmac, cmac, AES_BLOCK_SIZE);
+        PRINTF("xorend' %.*h\n", AES_BLOCK_SIZE, cmac);
+    }
+    // T = dbl(D) xor pad(Sn)
+    else {
+        double_block(cmac);
+        uint8_t padded[AES_BLOCK_SIZE];
+        padding(plaintext, ciphertext_len, padded);
+        xor_buffers(padded, cmac, cmac, AES_BLOCK_SIZE);
+        PRINTF("xor'd padded %.*h\n", AES_BLOCK_SIZE, cmac);
+    }
+
+    // V = AES-CMAC(K, T)
+    aes_cmac(mac_rkd, subkey_len, cmac, AES_BLOCK_SIZE, cmac);
+
+    return parser_ok;
+}
+
+parser_error_t aes_siv_decrypt(
+    const uint8_t *keys,
+    size_t keys_len,
+    const uint8_t *payload,
+    size_t payload_len,
+    uint8_t *out,
+    uint16_t *out_len
+) {
+    // AES-128 only
+    if (keys_len != 32) {
+        return parser_invalid_tek_data;
+    }
+
+    // write plaintext directly to output
+    uint8_t *plaintext = (uint8_t *)out;
+
+    // extract the keys
+    size_t subkey_len = keys_len / 2;
+    const uint8_t *mac_rkd = keys;
+    const uint8_t *ctr_rkd = keys + subkey_len;
+
+    // init ctr key
+    cx_aes_key_t ctr_key;
+    cx_err_t aes_err = cx_aes_init_key_no_throw(ctr_rkd, subkey_len, &ctr_key);
+    if(aes_err != CX_OK) return parser_aes_init_error;
+
+    // extract tag from payload
+    const uint8_t *tag = (const uint8_t *)payload;
+
+    // extract ciphertext from payload
+    size_t ciphertext_len = payload_len - AES_BLOCK_SIZE;
+    const uint8_t *ciphertext = payload + AES_BLOCK_SIZE;
+
+    // init iv using tag
+    uint8_t ctr_iv[AES_BLOCK_SIZE];
+    memcpy(ctr_iv, tag, AES_BLOCK_SIZE);
+
+    // zero out top bits in last 32-bit words of iv
+    ctr_iv[AES_BLOCK_SIZE - 8] &= 0x7f;
+    ctr_iv[AES_BLOCK_SIZE - 4] &= 0x7f;
+
+    // prep block buffer
+    uint8_t block_data[AES_BLOCK_SIZE];
+
+    // the shared secret prefix will get skipped during decoding
+    size_t plaintext_len = ciphertext_len - SHARED_SECRET_LEN;
+
+    // make sure not to exceed the bounds of the output buffer
+    plaintext_len = MIN(plaintext_len, out_len);
+
+    // use read/write pointers for ciphertext/plaintext, respectively
+    uint8_t *read = ciphertext;
+    uint8_t *write = plaintext - SHARED_SECRET_LEN;
+
+    // decrypt blocks using AES-CTR
+    for (size_t block_idx = 0; block_idx < ciphertext_len; block_idx += AES_BLOCK_SIZE) {
+        // compute intrinsic size of block
+        size_t block_len = ciphertext_len - block_idx;
+        block_len = MIN(block_len, AES_BLOCK_SIZE);
+
+        // encrypt next ctr (Ledger's cx_aes_no_throw crashes the app)
+        cx_aes(&ctr_key, CX_ENCRYPT, ctr_iv, AES_BLOCK_SIZE, block_data, AES_BLOCK_SIZE);
+
+        // update counter
+        for (int byte_idx = AES_BLOCK_SIZE-1; byte_idx >= 0; --byte_idx) {
+            ctr_iv[byte_idx]++;
+            if (ctr_iv[byte_idx] != 0) break;
+        }
+
+        // only write once within bounds
+        if (write >= plaintext) {
+            // make sure not to exceed the bounds of the output buffer
+            size_t write_offset = block_idx - SHARED_SECRET_LEN;
+            block_len = MIN(block_len, plaintext_len - write_offset);
+
+            xor_buffers(read, block_data, write, block_len);
+        }
+
+        // advance read/write pointers
+        read += block_len;
+        write += block_len;
+    }
+
+    // set output length
+    *out_len = write >= plaintext? write - plaintext: 0;
+
+    // TODO: finish s2v impl
+
+    // PRINTF("init mac rkd: %.*h\n", subkey_len, mac_rkd);
+
+    // uint8_t cmac[AES_BLOCK_SIZE];
+    // aes_s2v(mac_rkd, plaintext, ciphertext_len, cmac);
+
+    // PRINTF("performed 2nd cmac %.*h <> %.*h\n", AES_BLOCK_SIZE, cmac, AES_BLOCK_SIZE, tag);
+
+    // // check that the computed mac matches the provided tag
+    // if (memcmp(cmac, tag, AES_BLOCK_SIZE) != 0) {
+
+    //     // mac mismatch, data is corrupted
+    //     // memset(plaintext, 0, ciphertext_len);
+    //     return -1;
+    // }
+
+    return parser_ok;
+}
+
+
+
+parser_error_t decrypt_secret_wasm_msg(uint8_t *in, uint16_t in_len, uint8_t *out, uint16_t *out_len) {
+    // determine max size needed for base64 decoded data and prepare a VLA
+    uint16_t max_len = BASE64_DECODED_LEN(in_len);
+    uint8_t imperative_buffer[*out_len >= max_len? 0: max_len];
+
+    // attempt to use output as a buffer for intermediate data; use imperative buffer as fallback
+    uint8_t *decoded = out;
+    if (max_len > out_len) decoded = imperative_buffer;
+
+    // set maximum amount of space available to use in buffer; then get actual used
+    uint16_t decoded_len = *out_len;
+
+    // base64 decode the string
+    int decode_error = base64_decode(
+        in,
+        in_len,
+        decoded,
+        &decoded_len
+    );
+
+    // invalid base64
+    if (decode_error != 0) return parser_invalid_msg_contents;
+
+    // skip preamble to get to payload
+    uint16_t payload_len = decoded_len - MSG_PREAMBLE_LEN;
+    uint8_t *payload = (uint8_t *)decoded + MSG_PREAMBLE_LEN;
+
+    // write plaintext directly to output
+    uint8_t *plaintext = (uint8_t *)out;
+    uint16_t plaintext_len;
+
+    // attempt to decrypt the payload
+    parser_error_t decrypt_error = aes_siv_decrypt(
+        parser_tx_obj.tek_data,
+        parser_tx_obj.tek_k,
+        payload,
+        payload_len,
+        plaintext,
+        &plaintext_len
+    );
+
+    if (decrypt_error != CX_OK) return decrypt_error;
+
+    // trim end of string
+    uint8_t *write = plaintext + plaintext_len;
+    while (write-- > plaintext && (*write == '\0' || *write == ' ')) {
+        *write = '\0';
+    }
+
+    // update length
+    plaintext_len = write + 1 - plaintext;
+
+    // replace codepoints outside the ASCII range with a single character
+    write = plaintext;
+    uint8_t *read = plaintext;
+    while (read < plaintext + plaintext_len && *read != '\0') {
+        utf8_int32_t codepoint;
+        read = (uint8_t *)utf8codepoint((const char *)read, &codepoint);
+
+        // write to buffer, replacing extended character with ASCII
+        *write++ = codepoint > 0x7f? '+': (char)codepoint;
+    }
+
+    // write final length
+    *out_len = write - plaintext;
+
+    return parser_ok;
+}

--- a/app/src/secret_wasm.h
+++ b/app/src/secret_wasm.h
@@ -19,12 +19,21 @@
 #include "parser_impl.h"
 
 #define AES_BLOCK_SIZE 16
+#define AES_SIV_SUBKEY_LEN 16
 #define MSG_PREAMBLE_LEN 64
 #define SHARED_SECRET_LEN 64
 
+static const uint8_t zero_block[AES_BLOCK_SIZE] = {0};
+
 static const char key_wasm_msg[] = "msgs/value/msg";
 
-parser_error_t aes_siv_decrypt(
+typedef struct {
+    cx_aes_key_t *mac_key;
+    const uint8_t *k1;
+    const uint8_t *k2;
+} cmac_context_t;
+
+parser_error_t aes_siv_open(
     const uint8_t *key,
     size_t key_len,
     const uint8_t *payload,

--- a/app/src/secret_wasm.h
+++ b/app/src/secret_wasm.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
-*  (c) 2019 Zondax GmbH
+*   (c) 2023 Solar Republic LLC
 *
 *  Licensed under the Apache License, Version 2.0 (the "License");
 *  you may not use this file except in compliance with the License.
@@ -13,37 +13,24 @@
 *  See the License for the specific language governing permissions and
 *  limitations under the License.
 ********************************************************************************/
-#pragma once
 
-#include "parser_common.h"
-#include <zxmacros.h>
-#include "zxtypes.h"
-#include "json/json_parser.h"
-#include "parser_txdef.h"
-#include "txmode_def.h"
+#include <stdio.h>
+#include <stdint.h>
+#include "parser_impl.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#define AES_BLOCK_SIZE 16
+#define MSG_PREAMBLE_LEN 64
+#define SHARED_SECRET_LEN 64
 
-typedef struct {
-    char str1[50];
-    char str2[50];
-} key_subst_t;
+static const char key_wasm_msg[] = "msgs/value/msg";
 
-typedef struct {
-    char str1[50];
-    char str2[50];
-} value_subst_t;
+parser_error_t aes_siv_decrypt(
+    const uint8_t *key,
+    size_t key_len,
+    const uint8_t *payload,
+    size_t payload_len,
+    uint8_t *plaintext,
+    uint16_t *out_len
+);
 
-extern parser_tx_t parser_tx_obj;
-
-parser_error_t parser_init(parser_context_t *ctx,
-                           const uint8_t *buffer,
-                           size_t bufferSize);
-
-parser_error_t _readTx(parser_context_t *c, tx_mode_t mode, parser_tx_t *v);
-
-#ifdef __cplusplus
-}
-#endif
+parser_error_t decrypt_secret_wasm_msg(uint8_t *in, uint16_t in_len, uint8_t *out, uint16_t *out_len);

--- a/app/src/secret_wasm.h
+++ b/app/src/secret_wasm.h
@@ -22,6 +22,7 @@
 #define AES_SIV_SUBKEY_LEN 16
 #define MSG_PREAMBLE_LEN 64
 #define SHARED_SECRET_LEN 64
+#define CODE_HASH_LEN 64
 
 static const uint8_t zero_block[AES_BLOCK_SIZE] = {0};
 

--- a/app/src/tx_display.h
+++ b/app/src/tx_display.h
@@ -19,6 +19,7 @@
 #include <stdint.h>
 #include <common/parser_common.h>
 #include "parser_txdef.h"
+#include "txmode_def.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -43,7 +44,7 @@ parser_error_t tx_display_query(uint16_t displayIdx,
                                 uint16_t *ret_value_token_index);
 
 parser_error_t tx_display_readTx(parser_context_t *c,
-                                 const uint8_t *data, size_t dataLen);
+                                 const uint8_t *data, size_t dataLen, tx_mode_t mode);
 
 parser_error_t tx_display_numItems(uint8_t *num_items);
 

--- a/app/src/tx_parser.h
+++ b/app/src/tx_parser.h
@@ -52,7 +52,7 @@ parser_error_t tx_traverse(int16_t root_token_index, uint8_t *numChunks);
 // Retrieves the value for the corresponding token index. If the value goes beyond val_len, the chunk_idx will be used
 parser_error_t tx_getToken(uint16_t token_index,
                            char *out_val, uint16_t out_val_len,
-                           uint8_t pageIdx, uint8_t *pageCount);
+                           uint8_t pageIdx, uint8_t *pageCount, char *key);
 
 __Z_INLINE bool is_msg_type_field(char *field_name) {
     return strcmp(field_name, "msgs/type") == 0;

--- a/app/src/txmode_def.h
+++ b/app/src/txmode_def.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
-*  (c) 2019 Zondax GmbH
+*  (c) 2023 Solar Republic LLC
 *
 *  Licensed under the Apache License, Version 2.0 (the "License");
 *  you may not use this file except in compliance with the License.
@@ -15,35 +15,10 @@
 ********************************************************************************/
 #pragma once
 
-#include "parser_common.h"
-#include <zxmacros.h>
-#include "zxtypes.h"
-#include "json/json_parser.h"
-#include "parser_txdef.h"
-#include "txmode_def.h"
+#include <stdint.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-typedef struct {
-    char str1[50];
-    char str2[50];
-} key_subst_t;
-
-typedef struct {
-    char str1[50];
-    char str2[50];
-} value_subst_t;
-
-extern parser_tx_t parser_tx_obj;
-
-parser_error_t parser_init(parser_context_t *ctx,
-                           const uint8_t *buffer,
-                           size_t bufferSize);
-
-parser_error_t _readTx(parser_context_t *c, tx_mode_t mode, parser_tx_t *v);
-
-#ifdef __cplusplus
-}
-#endif
+typedef uint8_t tx_mode_t;
+enum {
+    TX_MODE_RAW = 0,
+    TX_MODE_DECRYPT = 1
+};

--- a/docs/APDUSPEC.md
+++ b/docs/APDUSPEC.md
@@ -140,4 +140,54 @@ The signature data is DER encoded. The returned bytes have the following structu
 0x30 <length of whole message> <0x02> <length of R> <R> 0x2 <length of S> <S>
 ```
 
+### SIGN_SECP256K1_DECRYPT
+
+Same as [SIGN_SECP256K1](#SIGN_SECP256K1) except allows for decrypting the contents of Secret WASM contract messages by providing the AES-128-SIV transaction encryption key.
+
+#### Command
+
+| Field | Type     | Content                | Expected  |
+| ----- | -------- | ---------------------- | --------- |
+| CLA   | byte (1) | Application Identifier | 0x55      |
+| INS   | byte (1) | Instruction ID         | 0x42      |
+| P1    | byte (1) | Payload desc           | 0 = init  |
+|       |          |                        | 1 = add   |
+|       |          |                        | 2 = last  |
+| P2    | byte (1) | ----                   | not used  |
+| L     | byte (1) | Bytes in payload       | (depends) |
+
+The first packet/chunk includes only the derivation path
+
+All other packets/chunks should contain the combined payload data
+
+*First Packet*
+
+| Field      | Type     | Content                | Expected  |
+| ---------- | -------- | ---------------------- | --------- |
+| Path[0]    | byte (4) | Derivation Path Data   | 44        |
+| Path[1]    | byte (4) | Derivation Path Data   | 529       |
+| Path[2]    | byte (4) | Derivation Path Data   | ?         |
+| Path[3]    | byte (4) | Derivation Path Data   | ?         |
+| Path[4]    | byte (4) | Derivation Path Data   | ?         |
+
+*Other Chunks/Packets*
+
+| Field    | Type           | Content         | Expected    |
+| -------- | -------------- | --------------- | ----------- |
+| TxKeyLen | byte (1)       | SIV key size    | 0 or 32     |
+| TxKey    | byte (0|32)    | AES-128-SIV key |             |
+| Message  | bytes...       | Message to Sign |             |
+
+#### Response
+
+| Field   | Type      | Content     | Note                     |
+| ------- | --------- | ----------- | ------------------------ |
+| SIG     | byte (variable) | Signature   |                          |
+| SW1-SW2 | byte (2)  | Return code | see list of return codes |
+
+The signature data is DER encoded. The returned bytes have the following structure.
+
+```
+0x30 <length of whole message> <0x02> <length of R> <R> 0x2 <length of S> <S>
+```
 --------------

--- a/fuzzing/parser_parse.cpp
+++ b/fuzzing/parser_parse.cpp
@@ -26,7 +26,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     fprintf(stderr, "----------------------------------------------\n");
 
-    rc = parser_parse(&ctx, data, size);
+    rc = parser_parse(&ctx, data, size, TX_MODE_RAW);
     if (rc != parser_ok) {
         return 0;
     }

--- a/tests/tx_parse.cpp
+++ b/tests/tx_parse.cpp
@@ -34,7 +34,7 @@ namespace {
 
         return tx_getToken(ret_value_token_index,
                            parser_tx_obj.query.out_val, parser_tx_obj.query.out_val_len,
-                           parser_tx_obj.query.page_index, numChunks);
+                           parser_tx_obj.query.page_index, numChunks, NULL);  // get_required_root_item(ret_value_token_index)
     }
 #pragma clang diagnostic pop
 

--- a/tests/ui_tests.cpp
+++ b/tests/ui_tests.cpp
@@ -33,7 +33,7 @@ void validate_testcase(const testcase_t &tc) {
     const auto *buffer = (const uint8_t *) tc.tx.c_str();
     size_t bufferLen = tc.tx.size();
 
-    err = parser_parse(&ctx, buffer, bufferLen);
+    err = parser_parse(&ctx, buffer, bufferLen, TX_MODE_RAW);
     ASSERT_EQ(parser_getErrorDescription(err), tc.parsingErr) << "Parsing error mismatch";
 
     if (err != parser_ok)
@@ -52,7 +52,7 @@ void check_testcase(const testcase_t &tc) {
     const auto *buffer = (const uint8_t *) tc.tx.c_str();
     size_t bufferLen = tc.tx.size();
 
-    err = parser_parse(&ctx, buffer, bufferLen);
+    err = parser_parse(&ctx, buffer, bufferLen, TX_MODE_RAW);
     ASSERT_EQ(parser_getErrorDescription(err), tc.parsingErr)  << "Parsing error mismatch";
 
     if (err != parser_ok)

--- a/tests_zemu/package.json
+++ b/tests_zemu/package.json
@@ -19,7 +19,9 @@
   },
   "dependencies": {
     "@zondax/zemu": "^0.32.0",
-    "ledger-cosmos-js": "^2.1.8"
+    "ledger-cosmos-js": "^2.1.8",
+    "ledger-secret-js": "^0.0.2",
+    "secretjs": "^1.9.3"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",

--- a/tests_zemu/tests/common.ts
+++ b/tests_zemu/tests/common.ts
@@ -240,3 +240,30 @@ export const ibc_denoms = {
   ],
   sequence: '1'
 }
+
+export const example_tx_str_execute = {
+  account_number: '1',
+  chain_id: 'secret-4',
+  fee: {
+    amount: [
+      {
+        amount: '4000',
+        denom: 'uscrt',
+      },
+    ],
+    gas: '200000',
+  },
+  memo: '',
+  msgs: [
+    {
+      type: 'wasm/MsgExecuteContract',
+      value: {
+        contract: 'secret1k0jntykt7e4g3y88ltc60czgjuqdy4c9e8fzek',
+        msg: '01vgUGLEoBQLuvmdI1iyurOwWFzG5z/iWet4e9aZ0ZY6Cey5m7/GAsbb35avP/B4Qj3xXJzs4ymOoCdiTPZ/a/y6m8Fno76ANrbR/uErwnOtzI+0PeYhKwoRcQeDLtxbu21yCI6YvIyNKmcII1A3KrJaGxknjevHapAKFn+WwDlNmIMA3+d4vHtwe0F347hR6SyTT8lZDYMSwJ+DOK3yypMChkRYP1MVbVfq0hOD4aT6VUSi8lHBiboXr2maWH55fqlPFcctmYl50ZhBGS83ZXcDX1MDJNjWQg6A2kuGSWUWW6NjTtf7rAiVv5AJXNiB',
+        sender: 'secret15zcng5c36ddh9q8wtv597ludtswudgrdthp5al',
+        sent_funds: [],
+      },
+    },
+  ],
+  sequence: '1'
+}

--- a/tests_zemu/tests/secret.test.ts
+++ b/tests_zemu/tests/secret.test.ts
@@ -1,0 +1,61 @@
+import Zemu from '@zondax/zemu'
+// @ts-ignore
+import SecretApp from 'ledger-secret-js'
+import { DEFAULT_OPTIONS, DEVICE_MODELS, example_tx_str_execute } from './common'
+
+// @ts-ignore
+import secp256k1 from 'secp256k1/elliptic'
+// @ts-ignore
+import crypto from 'crypto'
+import { fromHex } from 'secretjs'
+
+jest.setTimeout(60000)
+
+describe('Secret Network', function () {
+  test.each(DEVICE_MODELS)('sign basic with extra fields', async function (m) {
+    const sim = new Zemu(m.path)
+    try {
+      await sim.start({ ...DEFAULT_OPTIONS, model: m.name })
+      const app = new SecretApp(sim.getTransport())
+
+      const path = [44, 529, 0, 0, 0]
+      const tx = JSON.stringify(example_tx_str_execute)
+
+      // get address / publickey
+      const respPk = await app.getAddressAndPubKey(path, 'secret')
+      expect(respPk.return_code).toEqual(0x9000)
+      expect(respPk.error_message).toEqual('No errors')
+      console.log(respPk)
+
+      // tx encryption key
+      const txKey = fromHex('4c99abfc82816e168ff59c4468fe222d7aa00bbc37cb8ec7b33698d6a9b6fb28')
+        
+      const request = app.signTransparent(path, new TextEncoder().encode(tx), txKey)
+
+      // Wait until we are not in the main menu
+      await sim.waitUntilScreenIsNot(sim.getMainMenuSnapshot())
+      await sim.compareSnapshotsAndApprove('.', `${m.prefix.toLowerCase()}-sign_secret_wasm_decrypt`)
+
+      const resp = await request as any
+      console.log(resp)
+
+      expect(resp.return_code).toEqual(0x9000)
+      expect(resp.error_message).toEqual('No errors')
+      expect(resp).toHaveProperty('signature')
+
+      // Now verify the signature
+      const hash = crypto.createHash('sha256')
+      const msgHash = Uint8Array.from(hash.update(tx).digest())
+
+      const signatureDER = resp.signature
+      const signature = secp256k1.signatureImport(Uint8Array.from(signatureDER))
+
+      const pk = Uint8Array.from(respPk.compressed_pk)
+
+      const signatureOk = secp256k1.ecdsaVerify(signature, msgHash, pk)
+      expect(signatureOk).toEqual(true)
+    } finally {
+      await sim.close()
+    }
+  })
+})


### PR DESCRIPTION
# Feature Request: Decrypt Wasm Messages (Draft)

This PR introduces the ability for the Ledger app to decrypt the message being sent to Secret WASM contracts, allowing users to see the actual message contents they are signing (e.g., details of SNIP transfers) instead of the base64-encoded buffer of the encrypted message.

### How it works

A new instruction code `0x42 #SIGN_SECP256K1_DECRYPT` is introduced in order to remain backwards-compatible. The new instruction allows callers to include an optional AES-128-SIV key (the transaction encryption key) which was used to encrypt the WASM message ([see docs preview here](https://github.com/SecretSaturn/ledger-secret/compare/main...SolarRepublic:ledger-secret:feat/decrypt-secret-wasm?expand=1#diff-339d28470b499f619bca9c30ca1c14abeb82f3e64c4f9c36b9d0f7a1dfe70160)).

The app then performs all the same checks and parsing as it does with `0x02 #SIGN_SECP256K1`, in addition to verifying authenticity/integrity of the encrypted data via CMAC.

When displaying pages to the users, the app replaces the encrypted base64-encoded string with the decrypted message contents, allowing for transparent signing.
<img width="256" alt="Screenshot 2023-04-07 at 23 54 31" src="https://user-images.githubusercontent.com/1456400/230747967-0afed6b1-cdf1-45d2-87f4-95c210360c57.png">

This approach ensures that the app is still signing the exact same payload as before, and that a malicious caller would not be able to trick users into signing a different message (e.g., by providing a false decryption key).

### A note on app size

This implementation makes use of system libraries and already imported libs wherever possible, maintaining as small a footprint as possible to cut down on app size. v2.34.1 of the Secret app for Nano S is currently 46 KB (1/3rd the capacity of the device). Upon reviewing the entire source code, I believe there is a fair amount of optimization that can be done to reduce this size. A follow-up item will be to attempt to apply these optimizations.

### Steps remaining before PR is moved out of draft status:
 - [x] Finish S2V implementation
 - [ ] Add comprehensive test coverage
 - [ ] Reduce size of app by optimizing parts of Zondax's implementation
 - [ ] Report on output binary size difference affected by changes